### PR TITLE
Expose the narrow-band DC remesh band width as --band / per-request band

### DIFF
--- a/include/trellis_args.h
+++ b/include/trellis_args.h
@@ -36,6 +36,10 @@ struct TrellisParams {
                                 // as background and the model then generates holes there.)
     bool texture  = true;       // texture flow + UV bake (else geometry-only)
     bool xatlas   = true;       // xatlas UV unwrap (else voxel-native box projection)
+    int  band     = 1;          // narrow-band DC remesh band width (remesh_dc.h).
+                                //   1 = reference default; 2 = thicker offset shell,
+                                //   suppresses the doubled inner skin some subjects
+                                //   develop at band 1 (thin walls, chairs, vessels)
     int  decim    = -1;         // decimation cluster grid   (-1 => per-cascade default)
     int  tex      = -1;         // UV atlas size in px        (-1 => per-cascade default)
     int  tex_res  = -1;         // texture PBR resolution: -1 => auto (drop dense res-1024 tex to

--- a/src/trellis-server.cpp
+++ b/src/trellis-server.cpp
@@ -4,7 +4,8 @@
 //   POST /generate    multipart/form-data with an "image" file part; optional text
 //                      fields "seed", "resolution" (512/1024/1536), "bg_removal"
 //                      (threshold|birefnet), "uv" (xatlas = default, unique
-//                      chart space; box = faster projection). Returns
+//                      chart space; box = faster projection), "band" (narrow-band
+//                      DC remesh band width, default 1 — see --band). Returns
 //                      model/gltf-binary.
 //
 // Launch-time defaults come from CLI flags (see trellis::parse_args);
@@ -97,6 +98,7 @@ int main(int argc, char** argv) {
         if (req.has_file("resolution")) p.set_res(atoi(req.get_file_value("resolution").content.c_str()));
         if (req.has_file("bg_removal")) p.birefnet = (req.get_file_value("bg_removal").content == "birefnet") ? 1 : 0;
         if (req.has_file("uv")) p.xatlas = (req.get_file_value("uv").content == "xatlas");
+        if (req.has_file("band")) p.band = atoi(req.get_file_value("band").content.c_str());
 
         const std::string stem = temp_stem();
         p.image  = stem + ".png";

--- a/src/trellis_args.cpp
+++ b/src/trellis_args.cpp
@@ -36,6 +36,9 @@ void print_usage(const char* argv0, bool server) {
         "      --no-texture        geometry only\n"
         "      --xatlas            xatlas UV unwrap (default)\n"
         "      --box-uv            voxel-native box projection (faster)\n"
+        "      --band N            narrow-band DC remesh band width (default 1;\n"
+        "                          2 = thicker offset shell, suppresses the doubled\n"
+        "                          inner skin thin-walled subjects develop at 1)\n"
         "      --decim GRID        legacy cluster-grid decimation (default: quadric\n"
         "                          simplify to 300K faces @1024 / 150K @512; 0 = none)\n"
         "      --atlas PX          UV atlas size (default 2048 @1024 / 1024 @512)\n"
@@ -79,6 +82,7 @@ bool parse_args(int argc, char** argv, TrellisParams& p) {
         else if (a == "--no-texture")           { p.texture = false; }
         else if (a == "--xatlas")               { p.xatlas = true; }
         else if (a == "--box-uv")               { p.xatlas = false; }
+        else if (a == "--band")                 { const char* v = need(a.c_str()); if (!v) return false; p.band = atoi(v); }
         else if (a == "--decim")                { const char* v = need(a.c_str()); if (!v) return false; p.decim = atoi(v); }
         else if (a == "--atlas" || a == "--tex"){ const char* v = need(a.c_str()); if (!v) return false; p.tex = atoi(v); }
         else if (a == "--tex-res")              { const char* v = need(a.c_str()); if (!v) return false; p.tex_res = atoi(v); }

--- a/src/trellis_cli.cpp
+++ b/src/trellis_cli.cpp
@@ -366,7 +366,7 @@ int trellis_run(const trellis::TrellisParams& cfg) {
                                                      mesh.faces.data(), mesh.F());
         trellis::Mesh rm = trellis::remesh_narrow_band_dc(mesh.verts.data(), mesh.V(),
                                                           mesh.faces.data(), mesh.F(),
-                                                          bvh, so.res);
+                                                          bvh, so.res, cfg.band);
         // Clean the narrow-band DC output (drop degenerate faces, unify winding), then drop
         // decode floaters (the reference is a single watertight component; ours shattered into
         // 50+ pieces). The faithful QEM simplifier below handles surface smoothing via its


### PR DESCRIPTION
## What

`remesh_narrow_band_dc()` already takes a `band` parameter (default 1), but
nothing plumbs it to the surface: the CLI has no flag and the server has no
request field. This PR wires it through:

- `TrellisParams.band` (default 1 — behavior unchanged),
- `--band N` CLI flag (+ usage text),
- optional `band` multipart field on `POST /generate`,
- the CLI call site passes `cfg.band` instead of relying on the default.

No behavior change unless the flag is used.

## Why

At `band = 1`, thin-walled subjects (chairs, vessels, shells) frequently come
out with a **doubled inner skin**: a second, complete skin a small distance
under the outer one, anti-parallel normals, sometimes welded into the same
component. On our test set (several chairs at res 512), 58–63% of faces have
an anti-parallel partner within 0.6% of the bbox diagonal — i.e. most of the
surface is doubled.

This matches the reference implementation's known behavior: in the original
CuMesh/o_voxel postprocess the same artifact appears at narrow band widths and
disappears at `band = 2` (at the cost of slightly less surface detail). We have
been running the reference pipeline with `band = 2` in production for weeks
specifically for this reason; with trellis.cpp we could not, because the knob
is hardcoded.

With this patch, launching `trellis-server --band 2` (or passing `band=2` per
request) produces single-skin, watertight meshes on the same subjects that
double-skin at the default.

## Notes

- Default stays 1 so reference-parity comparisons are unaffected.
- `band` interacts with `eps = band·scale/res` (see remesh_dc.h): 2 doubles the
  offset distance, which is exactly what prevents the inner/outer crust from
  separating into two skins on thin geometry.
- Happy to add a note to the README if you want the trade-off documented.